### PR TITLE
mypage and profile united

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ export const App = () => {
             <Route path="/signup" element={<Signup />} />\
             <Route path="/rating" element={<Rating />} />
             <Route path="/news" element={<News />} />
-            <Route path="/profile/:user_id" element={<Profile />} />
+            <Route path="/profile/:view_user_id" element={<Profile />} />
             <Route
               path="/profile/:page_user_id/collections"
               element={<Collections />}

--- a/src/pages/mypage/Profile.tsx
+++ b/src/pages/mypage/Profile.tsx
@@ -35,7 +35,7 @@ export const Profile = () => {
   }, [viewUserId]);
 
   // Check if the user is viewing their own profile
-  if(user_id === viewUserId) {
+  if (user_id === viewUserId) {
     return <MyPage />;
   }
 

--- a/src/pages/mypage/Profile.tsx
+++ b/src/pages/mypage/Profile.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
-import { FaCog } from 'react-icons/fa'; //
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import { useAuth } from '../../components/AuthContext';
 import { Footerbar } from '../../components/Footerbar';
 import { type UserProfile } from '../../utils/Types';
+import { MyPage } from './MyPage';
 
 export const Profile = () => {
-  const { user_id } = useParams();
+  const { view_user_id } = useParams();
+  const viewUserId = Number(view_user_id);
+  const { user_id } = useAuth();
   const navigate = useNavigate();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [following, setFollowing] = useState(false);
@@ -14,10 +17,10 @@ export const Profile = () => {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        if (user_id === undefined) {
+        if (isNaN(viewUserId)) {
           throw new Error('User ID is undefined');
         }
-        const response = await fetch(`/api/users/profile/${user_id}`);
+        const response = await fetch(`/api/users/profile/${viewUserId}`);
         if (!response.ok) {
           throw new Error('Failed to fetch profile');
         }
@@ -29,16 +32,21 @@ export const Profile = () => {
     };
 
     void fetchProfile();
-  }, [user_id]);
+  }, [viewUserId]);
+
+  // Check if the user is viewing their own profile
+  if(user_id === viewUserId) {
+    return <MyPage />;
+  }
 
   // Handle follow/unfollow button click
   const toggleFollow = async () => {
     try {
-      if (user_id === undefined) {
+      if (isNaN(viewUserId)) {
         throw new Error('User ID is undefined');
       }
 
-      const endpoint = `/api/users/follow/${user_id}`;
+      const endpoint = `/api/users/follow/${viewUserId}`;
 
       const method = following ? 'DELETE' : 'POST';
 
@@ -81,11 +89,6 @@ export const Profile = () => {
               {<h1 className="text-xl font-bold">{profile?.status_message}</h1>}
             </div>
           </div>
-          <Link to="/mypage/settings">
-            <button className="absolute top-3 right-3 text-gray-600 hover:text-gray-800">
-              <FaCog className="w-6 h-6" />
-            </button>
-          </Link>
           {/* Follow Button */}
           <div className="w-full mt-3">
             <button
@@ -109,13 +112,13 @@ export const Profile = () => {
             <p className="text-gray-500">평가</p>
           </div>
           <div>
-            <p className="font-bold">{profile?.comment_count}</p>
+            <p className="font-bold">{profile?.review_count}</p>
             <p className="text-gray-500">코멘트</p>
           </div>
           <div
             onClick={() => {
-              if (user_id != null) {
-                void navigate(`/profile/${user_id}/collections`);
+              if (isNaN(viewUserId)) {
+                void navigate(`/profile/${viewUserId}/collections`);
               }
             }}
           >


### PR DESCRIPTION
mypage와 profile을 합쳤습니다. 기본적으로 profile을 호출하나, 파라미터가 로그인된 아이디와 동일하면 mypage 컴포넌트를 반환하도록 했습니다. 이때 useAuth()으로부터 불러오는 아이디가 user_id이어서 중복을 피하기 위해 profile/:view_user_id로 파라미터명을 바꿔주었습니다.

테스트 중 /api/users/profile/{user_id}의 response body에서 유저의 프로필에 떠야 할 평가(매긴 별점)의 수에 해당하는 요소가 없는 것을 발견했습니다.